### PR TITLE
Explore running PHPUnit tests with WordPress Playground

### DIFF
--- a/wp-tester.json
+++ b/wp-tester.json
@@ -1,0 +1,47 @@
+{
+  "$schema": "https://raw.githubusercontent.com/bgrgicak/wp-tester/trunk/packages/config/src/schema.json",
+  "projectType": "other",
+  "projectVFSPath": "/project",
+  "tests": {
+    "phpunit": {
+      "phpunitPath": "vendor/bin/phpunit",
+      "configPath": "phpunit.xml.dist",
+      "testMode": "unit",
+      "phpunitArgs": [
+        "--testsuite",
+        "default",
+        "--group",
+        "option,meta,query,post,user,term,comment,date,l10n"
+      ]
+    }
+  },
+  "environments": [
+    {
+      "name": "WordPress Core Tests",
+      "php": ["8.3"],
+      "blueprint": {
+        "steps": [
+          {
+            "step": "runPHP",
+            "code": "<?php\nrequire_once '/wordpress/wp-load.php';\n$site_url = home_url();\n$domain = parse_url($site_url, PHP_URL_HOST);\n$port = parse_url($site_url, PHP_URL_PORT);\nif ($port) {\n    $domain .= ':' . $port;\n}\ndefine('WP_HOME', $site_url);\ndefine('WP_SITEURL', $site_url);\ndefine('WP_TESTS_DOMAIN', $domain);\n?>"
+          }
+        ]
+      },
+      "mounts": [
+        {
+          "hostPath": "src",
+          "vfsPath": "/wordpress",
+          "beforeInstall": true
+        },
+        {
+          "hostPath": ".",
+          "vfsPath": "/project"
+        }
+      ],
+      "env": {
+        "WP_TESTS_DIR": "/project/tests/phpunit"
+      }
+    }
+  ],
+  "reporters": {}
+}


### PR DESCRIPTION
This PR explores running WordPress unit tests with Playground using WP Tester and PHPUnit.

The goal of this PR is to understand the limitations of Playground and WP Tester and it shouldn't be merged.



## Testing instructions

- Checkout this PR
- Install dependencies `composer install`
- Run tests `npx @wp-tester/cli test`


**Notes**
- There are some warnings at the start of the run related to extracting WordPress. They are a bug in WP Tester and are unrelated to the tests.
- This PR skips multisite tests.